### PR TITLE
fix installation missing dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,9 @@
 #! /usr/bin/env python
 
 import sys
-#try:
-#    from setuptools import setup
-#    have_setuptools = True
-#except ImportError:
-#    from distutils.core import setup
-#    have_setuptools = False
 
 # setuptools no longer works.
 from distutils.core import setup
-have_setuptools = False
 
 if sys.version_info[0] < 3:
     sys.exit("ERROR: xo requires Python 3.")
@@ -32,15 +25,13 @@ setup_kwargs = {
         "Topic :: Text Editors",
         ],
     "data_files": [("", ['license', 'readme.rst']),],
-    }
-
-if have_setuptools:
-    setup_kwargs['install_requires'] = [
+    "install_requires": [
         'Pygments >= 1.6',
         'urwid >= 1.1.1',
         'pygments_cache',
-        ]
-    setup_kwargs["zip_safe"] = False
+        ],
+    "zip_safe": False,
+    }
 
 if __name__ == '__main__':
     setup(


### PR DESCRIPTION
removing a dead variable (that only serves to break things) and commented-out dead code from when SetupTools was a thing.

I don't really know how `pip` and `setup.py` actually work, but I thought even I could understand how to close #20 and #19