### PR TITLE
unhandled_keypress: fix inconsistent behaviour of ctrl/meta right

### DIFF
--- a/news/move-cond
+++ b/news/move-cond
@@ -1,0 +1,14 @@
+**Added:**
+
+**Changed:**
+
+**Deprecated:**
+
+**Removed:**
+
+**Fixed:**
+
+* inconsistent handling of ctrl/meta + left and ctrl/meta + right
+  * ctrl+right used to be swapped with meta+right
+
+**Security:**

--- a/xo.py
+++ b/xo.py
@@ -856,7 +856,7 @@ class MainDisplay(object):
         elif k == "ctrl right" or k == "meta right":
             w, ypos = self.walker.get_focus()
             xpos = w.edit_pos
-            re_word = RE_WORD if k == "meta right" else RE_NOT_WORD
+            re_word = RE_WORD if k == "ctrl right" else RE_NOT_WORD
             m = re_word.search(w.edit_text or "", xpos)
             word_pos = xpos if m is None else m.end()
             w.set_edit_pos(word_pos)


### PR DESCRIPTION
this changed the `ctrl/meta right` behaviour to be consistent with `ctrl/meta left`

also mark xo.py executable for convenience

close #24 