### PR TITLE
Jedi integration

### DIFF
--- a/news/jedi_integration
+++ b/news/jedi_integration
@@ -1,0 +1,14 @@
+**Added:**
+
+* Optional name completion with the Jedi module (an awesome
+autocompletion/static analysis library for Python).
+
+**Changed:**
+
+**Deprecated:**
+
+**Removed:**
+
+**Fixed:**
+
+**Security:**

--- a/readme.rst
+++ b/readme.rst
@@ -13,7 +13,7 @@ You might be looking for help, but this is all I can do::
     optional arguments:
       -h, --help  show this help message and exit
 
-Someone else made a `video tutorial <http://youtu.be/bPq8fncImtQ>`_ and posted 
+Someone else made a `video tutorial <http://youtu.be/bPq8fncImtQ>`_ and posted
 it on YouTube within an hour of the 0.1 release.
 
 get xo
@@ -44,6 +44,7 @@ key commands
 :meta + s: select pygments style
 :ctrl + f: insert file at current position
 :ctrl + y: go to line & column (yalla, let's bounce)
+:ctrl + n: name completion with Jedi (if installed)
 
 :ctrl + k: cuts the current line to the clipboard
 :ctrl + u: pastes the clipboard to the current line

--- a/xo.py
+++ b/xo.py
@@ -41,7 +41,12 @@ from pygments.lexers.python import PythonLexer, Python3Lexer
 from pygments.token import Token
 from pygments.filter import Filter
 from pygments.styles import get_all_styles
-import jedi
+
+# Jedi is optional import for name completion
+try:
+    import jedi
+except ImportError:
+    jedi = None
 
 __version__ = '0.3.2'
 
@@ -993,17 +998,29 @@ class MainDisplay(object):
                 self.view.contents["footer"] = (self.status, None)
                 self.view.focus_position = "body"
         elif k == keybindings["name_complete"]:
-            curr_footer = self.view.contents["footer"][0]
-            if curr_footer is self.status:
-                self.get_name_complete_options()
-                # make a deque of name_complete_full_options
-                name_complete_full_options = deque()
-                for i in range(0, len(self.name_complete_options)):
-                    name_complete_full_options.append(self.name_complete_options[i].name)
-                self.view.contents["footer"] = (
-                    urwid.AttrMap(NameCompleteEditor(caption="name complete (up, down keys): ", edit_text="",
-                                  deq=name_complete_full_options), "foot"), None)
-                self.view.focus_position = "footer"
+                if jedi is not None:
+                    curr_footer = self.view.contents["footer"][0]
+                    if curr_footer is self.status:
+                        self.get_name_complete_options()
+                        # make a deque of name_complete_full_options
+                        name_complete_full_options = deque()
+                        for i in range(0, len(self.name_complete_options)):
+                            name_complete_full_options.append(self.name_complete_options[i].name)
+                        self.view.contents["footer"] = (
+                            urwid.AttrMap(NameCompleteEditor(caption="name complete (up, down keys): ", edit_text="",
+                            deq=name_complete_full_options), "foot"), None)
+                        self.view.focus_position = "footer"
+                else: # jedi module not found display error
+                    curr_footer = self.view.contents["footer"][0]
+                    if curr_footer is self.status:
+                        self.view.contents["footer"] = (
+                            urwid.AttrMap(urwid.Text(("jedi python module not installed\n" +
+                                "name completion failed.\n" +
+                                "easiest method to install jedi is\n" +
+                                "\"pip3 install jedi\"\n" +
+                                "press ESC to continue")), "foot"), None)
+                        self.view.focus_position = "footer"
+
         else:
             self.reset_status()
             return

--- a/xo.py
+++ b/xo.py
@@ -27,7 +27,6 @@ import io
 import sys
 import json
 import time
-import importlib.util
 from glob import glob
 from itertools import zip_longest
 from collections import deque

--- a/xo.py
+++ b/xo.py
@@ -27,12 +27,12 @@ import io
 import sys
 import json
 import time
+import importlib.util
 from glob import glob
 from itertools import zip_longest
 from collections import deque
 from collections.abc import Mapping, Sequence
 from argparse import ArgumentParser, RawDescriptionHelpFormatter, _StoreTrueAction
-
 import urwid
 import pygments.util
 import pygments_cache
@@ -41,12 +41,6 @@ from pygments.lexers.python import PythonLexer, Python3Lexer
 from pygments.token import Token
 from pygments.filter import Filter
 from pygments.styles import get_all_styles
-
-# Jedi is optional import for name completion
-try:
-    import jedi
-except ImportError:
-    jedi = None
 
 __version__ = '0.3.2'
 
@@ -690,6 +684,7 @@ class MainDisplay(object):
     def __init__(self):
         self.load_rc()
         self.set_keybindings()
+        self.jedi_imported_try = False
 
     def init_file(self, name):
         self.save_name = name
@@ -998,6 +993,16 @@ class MainDisplay(object):
                 self.view.contents["footer"] = (self.status, None)
                 self.view.focus_position = "body"
         elif k == keybindings["name_complete"]:
+                if self.jedi_imported_try == False: # this code perfoms a lazy import
+                    # lazy import is only done if it is needed the user pressed ctrl-n
+                    # if the jedi python module is not installed then the global jedi
+                    # variable is set to none producing an error message in footer
+                    global jedi
+                    try:
+                        import jedi
+                    except ImportError:
+                        jedi = None
+                    self.jedi_imported_try = True
                 if jedi is not None:
                     curr_footer = self.view.contents["footer"][0]
                     if curr_footer is self.status:


### PR DESCRIPTION

This commit is for issue #30 with three goals as directed by @scopatz:

1. I would like jedi to be optional, so that if you don't have it, nothing happens.
2. Also it would be good if the jedi import could be lazy so that startup time is still as fast as possible.
3. Please add a news file a la the instructions at https://regro.github.io/rever-docs/news

Thanks for the opportunity to help with xo! I use xo almost everyday so I am
glad I can lend a helping hand.  Please provide feedback and I will be happy
to make adjustments as needed.


# Optional Import

This is straight forward you basically put a import around try/except block,
if it fails then you know the module is not installed.  On failure simply
set the variable jedi to None.  Then any code that uses jedi simply checks
to see if jedi is not set to none.  I put this block in the name_completion
key handler on line 1001.

# Lazy Import

I am new to the world of lazy imports they are a newer concept in Python. My
first attempt using importlib.util doesn't seem to work with the Jedi Python
module.  It does work with the os module so I think my implementation is
correct.  I am not 100% sure what the issue is.....I have created an issue
on Jedi's GitHub to see if somebody can help me
[resolve](https://github.com/davidhalter/jedi/issues/1464).

Not to be discouraged I implementing without importlib just using a simple
variable called jedi_imported_try and got both the lazy import and the
optional import to work.  The code without importlib is actually shorter and
IMO easier to understand.  It might not be "pythonic" but it works.  Most of
the changes were to the name_completion key hander on line 996 - 1027.

# Adding a news file

Yes I added a news file this time and didn't delete the old news reports :-)
